### PR TITLE
Added anchor classes support

### DIFF
--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -2,81 +2,79 @@ const DepGraph = require("dependency-graph").DepGraph;
 const urlFilter = require("@11ty/eleventy/src/Filters/Url");
 
 function findNavigationEntries(nodes = [], key = "") {
-    let pages = [];
-    for (let entry of nodes) {
-        if (entry.data && entry.data.eleventyNavigation) {
-            let nav = entry.data.eleventyNavigation;
-            if (!key && !nav.parent || nav.parent === key) {
-                pages.push(Object.assign({}, nav, {
-                    url: entry.data.page.url,
-                    pluginType: "eleventy-navigation"
-                }, key ? {
-                    parentKey: key
-                } : {}));
-            }
-        }
-    }
+	let pages = [];
+	for(let entry of nodes) {
+		if(entry.data && entry.data.eleventyNavigation) {
+			let nav = entry.data.eleventyNavigation;
+			if(!key && !nav.parent || nav.parent === key) {
+				pages.push(Object.assign({}, nav, {
+					url: entry.data.page.url,
+					pluginType: "eleventy-navigation"
+				}, key ? { parentKey: key } : {}));
+			}
+		}
+	}
 
-    return pages.sort(function(a, b) {
-        return (a.order || 0) - (b.order || 0);
-    }).map(function(entry) {
-        if (!entry.title) {
-            entry.title = entry.key;
-        }
-        if (entry.key) {
-            entry.children = findNavigationEntries(nodes, entry.key);
-        }
-        return entry;
-    });
+	return pages.sort(function(a, b) {
+		return (a.order || 0) - (b.order || 0);
+	}).map(function(entry) {
+		if(!entry.title) {
+			entry.title = entry.key;
+		}
+		if(entry.key) {
+			entry.children = findNavigationEntries(nodes, entry.key);
+		}
+		return entry;
+	});
 }
 
 function findDependencies(pages, depGraph, parentKey) {
-    for (let page of pages) {
-        depGraph.addNode(page.key, page);
-        if (parentKey) {
-            depGraph.addDependency(page.key, parentKey)
-        }
-        if (page.children) {
-            findDependencies(page.children, depGraph, page.key);
-        }
-    }
+	for( let page of pages ) {
+		depGraph.addNode(page.key, page);
+		if(parentKey) {
+			depGraph.addDependency(page.key, parentKey)
+		}
+		if(page.children) {
+			findDependencies(page.children, depGraph, page.key);
+		}
+	}
 }
 
 function findBreadcrumbEntries(nodes, activeKey) {
-    let pages = findNavigationEntries(nodes);
-    let graph = new DepGraph();
-    findDependencies(pages, graph);
+	let pages = findNavigationEntries(nodes);
+	let graph = new DepGraph();
+	findDependencies(pages, graph);
 
-    return activeKey ? graph.dependenciesOf(activeKey).map(key => {
-        let data = Object.assign({}, graph.getNodeData(key));
-        delete data.children;
-        return data;
-    }) : [];
+	return activeKey ? graph.dependenciesOf(activeKey).map(key => {
+		let data = Object.assign({}, graph.getNodeData(key));
+		delete data.children;
+		return data;
+	}) : [];
 }
 
 function navigationToHtml(pages, options = {}) {
-    options = Object.assign({
-        listElement: "ul",
-        listItemElement: "li",
-        listClass: "",
-        listItemClass: "",
-        listItemHasChildrenClass: "",
-        anchorClass: "",
-        activeAnchorClass: "",
-        activeKey: "",
-        activeListItemClass: "",
-        showExcerpt: false,
-        isChildList: false
-    }, options);
+	options = Object.assign({
+		listElement: "ul",
+		listItemElement: "li",
+		listClass: "",
+		listItemClass: "",
+		listItemHasChildrenClass: "",
+		activeKey: "",
+		activeListItemClass: "",
+		anchorClass: "",
+		activeAnchorClass: "",
+		showExcerpt: false,
+		isChildList: false
+	}, options);
 
-    let isChildList = !!options.isChildList;
-    options.isChildList = true;
+	let isChildList = !!options.isChildList;
+	options.isChildList = true;
 
-    if (pages.length && pages[0].pluginType !== "eleventy-navigation") {
-        throw new Error("Incorrect argument passed to eleventyNavigationToHtml filter. You must call `eleventyNavigation` or `eleventyNavigationBreadcrumb` first, like: `collection.all | eleventyNavigation | eleventyNavigationToHtml | safe`");
-    }
+	if(pages.length && pages[0].pluginType !== "eleventy-navigation") {
+		throw new Error("Incorrect argument passed to eleventyNavigationToHtml filter. You must call `eleventyNavigation` or `eleventyNavigationBreadcrumb` first, like: `collection.all | eleventyNavigation | eleventyNavigationToHtml | safe`");
+	}
 
-    return pages.length ? `<${options.listElement}${!isChildList && options.listClass ? ` class="${options.listClass}"` : ''}>${pages.map(entry => {
+	return pages.length ? `<${options.listElement}${!isChildList && options.listClass ? ` class="${options.listClass}"` : ''}>${pages.map(entry => {
 		let liClass = [];
 		let aClass = [];
 		if(options.listItemClass) {
@@ -97,12 +95,12 @@ function navigationToHtml(pages, options = {}) {
 			liClass.push(options.listItemHasChildrenClass);
 		}
 
-	return `<${options.listItemElement}${liClass.length ? ` class="${liClass.join(" ")}"` : ''}><a ${aClass.length ? `class="${aClass.join(" ")}" ` : ''}href="${urlFilter(entry.url)}">${entry.title}</a>${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml(entry.children, options) : ""}</${options.listItemElement}>`;
-	}).join("\n")}</${options.listElement}>`: "";
+		return `<${options.listItemElement}${liClass.length ? ` class="${liClass.join(" ")}"` : ''}><a ${aClass.length ? `class="${aClass.join(" ")}" ` : ''}href="${urlFilter(entry.url)}">${entry.title}</a>${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml(entry.children, options) : ""}</${options.listItemElement}>`;
+	}).join("\n")}</${options.listElement}>` : "";
 }
 
 module.exports = {
-    findNavigationEntries,
-    findBreadcrumbEntries,
-    toHtml: navigationToHtml
+	findNavigationEntries,
+	findBreadcrumbEntries,
+	toHtml: navigationToHtml
 };

--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -81,8 +81,8 @@ function navigationToHtml(pages, options = {}) {
 			liClass.push(options.listItemClass);
 		}
 		if(options.activeKey === entry.key && options.activeListItemClass) {
-      liClass.push(options.activeListItemClass);
-      aClass.push(options.activeAnchorClass);
+			liClass.push(options.activeListItemClass);
+			aClass.push(options.activeAnchorClass);
 		}
 		if(options.listItemHasChildrenClass && entry.children && entry.children.length) {
 			liClass.push(options.listItemHasChildrenClass);

--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -59,6 +59,8 @@ function navigationToHtml(pages, options = {}) {
 		listClass: "",
 		listItemClass: "",
 		listItemHasChildrenClass: "",
+		anchorClass: "",
+		activeAnchorClass: "",
 		activeKey: "",
 		activeListItemClass: "",
 		showExcerpt: false,
@@ -74,17 +76,19 @@ function navigationToHtml(pages, options = {}) {
 
 	return pages.length ? `<${options.listElement}${!isChildList && options.listClass ? ` class="${options.listClass}"` : ''}>${pages.map(entry => {
 		let liClass = [];
+		let aClass = [ options.anchorClass ];
 		if(options.listItemClass) {
 			liClass.push(options.listItemClass);
 		}
 		if(options.activeKey === entry.key && options.activeListItemClass) {
-			liClass.push(options.activeListItemClass);
+      liClass.push(options.activeListItemClass);
+      aClass.push(options.activeAnchorClass);
 		}
 		if(options.listItemHasChildrenClass && entry.children && entry.children.length) {
 			liClass.push(options.listItemHasChildrenClass);
 		}
 
-		return `<${options.listItemElement}${liClass.length ? ` class="${liClass.join(" ")}"` : ''}><a href="${urlFilter(entry.url)}">${entry.title}</a>${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml(entry.children, options) : ""}</${options.listItemElement}>`;
+		return `<${options.listItemElement}${liClass.length ? ` class="${liClass.join(" ")}"` : ''}><a ${aClass.length ? ` class="${aClass.join(" ")}"` : ''}href="${urlFilter(entry.url)}">${entry.title}</a>${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml(entry.children, options) : ""}</${options.listItemElement}>`;
 	}).join("\n")}</${options.listElement}>` : "";
 }
 

--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -2,98 +2,107 @@ const DepGraph = require("dependency-graph").DepGraph;
 const urlFilter = require("@11ty/eleventy/src/Filters/Url");
 
 function findNavigationEntries(nodes = [], key = "") {
-	let pages = [];
-	for(let entry of nodes) {
-		if(entry.data && entry.data.eleventyNavigation) {
-			let nav = entry.data.eleventyNavigation;
-			if(!key && !nav.parent || nav.parent === key) {
-				pages.push(Object.assign({}, nav, {
-					url: entry.data.page.url,
-					pluginType: "eleventy-navigation"
-				}, key ? { parentKey: key } : {}));
-			}
-		}
-	}
+    let pages = [];
+    for (let entry of nodes) {
+        if (entry.data && entry.data.eleventyNavigation) {
+            let nav = entry.data.eleventyNavigation;
+            if (!key && !nav.parent || nav.parent === key) {
+                pages.push(Object.assign({}, nav, {
+                    url: entry.data.page.url,
+                    pluginType: "eleventy-navigation"
+                }, key ? {
+                    parentKey: key
+                } : {}));
+            }
+        }
+    }
 
-	return pages.sort(function(a, b) {
-		return (a.order || 0) - (b.order || 0);
-	}).map(function(entry) {
-		if(!entry.title) {
-			entry.title = entry.key;
-		}
-		if(entry.key) {
-			entry.children = findNavigationEntries(nodes, entry.key);
-		}
-		return entry;
-	});
+    return pages.sort(function(a, b) {
+        return (a.order || 0) - (b.order || 0);
+    }).map(function(entry) {
+        if (!entry.title) {
+            entry.title = entry.key;
+        }
+        if (entry.key) {
+            entry.children = findNavigationEntries(nodes, entry.key);
+        }
+        return entry;
+    });
 }
 
 function findDependencies(pages, depGraph, parentKey) {
-	for( let page of pages ) {
-		depGraph.addNode(page.key, page);
-		if(parentKey) {
-			depGraph.addDependency(page.key, parentKey)
-		}
-		if(page.children) {
-			findDependencies(page.children, depGraph, page.key);
-		}
-	}
+    for (let page of pages) {
+        depGraph.addNode(page.key, page);
+        if (parentKey) {
+            depGraph.addDependency(page.key, parentKey)
+        }
+        if (page.children) {
+            findDependencies(page.children, depGraph, page.key);
+        }
+    }
 }
 
 function findBreadcrumbEntries(nodes, activeKey) {
-	let pages = findNavigationEntries(nodes);
-	let graph = new DepGraph();
-	findDependencies(pages, graph);
+    let pages = findNavigationEntries(nodes);
+    let graph = new DepGraph();
+    findDependencies(pages, graph);
 
-	return activeKey ? graph.dependenciesOf(activeKey).map(key => {
-		let data = Object.assign({}, graph.getNodeData(key));
-		delete data.children;
-		return data;
-	}) : [];
+    return activeKey ? graph.dependenciesOf(activeKey).map(key => {
+        let data = Object.assign({}, graph.getNodeData(key));
+        delete data.children;
+        return data;
+    }) : [];
 }
 
 function navigationToHtml(pages, options = {}) {
-	options = Object.assign({
-		listElement: "ul",
-		listItemElement: "li",
-		listClass: "",
-		listItemClass: "",
-		listItemHasChildrenClass: "",
-		anchorClass: "",
-		activeAnchorClass: "",
-		activeKey: "",
-		activeListItemClass: "",
-		showExcerpt: false,
-		isChildList: false
-	}, options);
+    options = Object.assign({
+        listElement: "ul",
+        listItemElement: "li",
+        listClass: "",
+        listItemClass: "",
+        listItemHasChildrenClass: "",
+        anchorClass: "",
+        activeAnchorClass: "",
+        activeKey: "",
+        activeListItemClass: "",
+        showExcerpt: false,
+        isChildList: false
+    }, options);
 
-	let isChildList = !!options.isChildList;
-	options.isChildList = true;
+    let isChildList = !!options.isChildList;
+    options.isChildList = true;
 
-	if(pages.length && pages[0].pluginType !== "eleventy-navigation") {
-		throw new Error("Incorrect argument passed to eleventyNavigationToHtml filter. You must call `eleventyNavigation` or `eleventyNavigationBreadcrumb` first, like: `collection.all | eleventyNavigation | eleventyNavigationToHtml | safe`");
-	}
+    if (pages.length && pages[0].pluginType !== "eleventy-navigation") {
+        throw new Error("Incorrect argument passed to eleventyNavigationToHtml filter. You must call `eleventyNavigation` or `eleventyNavigationBreadcrumb` first, like: `collection.all | eleventyNavigation | eleventyNavigationToHtml | safe`");
+    }
 
-	return pages.length ? `<${options.listElement}${!isChildList && options.listClass ? ` class="${options.listClass}"` : ''}>${pages.map(entry => {
+    return pages.length ? `<${options.listElement}${!isChildList && options.listClass ? ` class="${options.listClass}"` : ''}>${pages.map(entry => {
 		let liClass = [];
-		let aClass = [ options.anchorClass ];
+		let aClass = [];
 		if(options.listItemClass) {
 			liClass.push(options.listItemClass);
 		}
-		if(options.activeKey === entry.key && options.activeListItemClass) {
-			liClass.push(options.activeListItemClass);
-			aClass.push(options.activeAnchorClass);
+		if(options.anchorClass) {
+			aClass.push(options.anchorClass);
+		}
+		if(options.activeKey === entry.key) {
+			if(options.activeListItemClass) {
+				liClass.push(options.activeListItemClass);
+			}
+			if(options.activeAnchorClass) {
+				aClass.push(options.activeAnchorClass);
+			}
 		}
 		if(options.listItemHasChildrenClass && entry.children && entry.children.length) {
 			liClass.push(options.listItemHasChildrenClass);
 		}
 
-		return `<${options.listItemElement}${liClass.length ? ` class="${liClass.join(" ")}"` : ''}><a ${aClass.length ? ` class="${aClass.join(" ")}"` : ''}href="${urlFilter(entry.url)}">${entry.title}</a>${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml(entry.children, options) : ""}</${options.listItemElement}>`;
-	}).join("\n")}</${options.listElement}>` : "";
+	return `<${options.listItemElement}${liClass.length ? ` class="${liClass.join(" ")}"` : ''}><a ${aClass.length ? `class="${aClass.join(" ")}" ` : ''}href="${urlFilter(entry.url)}">${entry.title}</a>${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml(entry.children, options) : ""}</${options.listItemElement}>`;
+	}).join("\n")}</${options.listElement}>`: "";
 }
 
 module.exports = {
-	findNavigationEntries,
-	findBreadcrumbEntries,
-	toHtml: navigationToHtml
+    findNavigationEntries,
+    findBreadcrumbEntries,
+    toHtml: navigationToHtml
 };

--- a/test/navigationTest.js
+++ b/test/navigationTest.js
@@ -256,11 +256,24 @@ test("Checking active class on output HTML", t => {
 	let html = EleventyNavigation.toHtml(obj);
 	t.true(html.indexOf(`<li><a href="child1.html">child1</a></li>`) > -1);
 
-	let activeHtml = EleventyNavigation.toHtml(obj, {
+	let activeHtmlItem = EleventyNavigation.toHtml(obj, {
 		activeKey: "child1",
 		activeListItemClass: "this-is-the-active-item"
 	});
-	t.true(activeHtml.indexOf(`<li class="this-is-the-active-item"><a href="child1.html">child1</a></li>`) > -1);
+	t.true(activeHtmlItem.indexOf(`<li class="this-is-the-active-item"><a href="child1.html">child1</a></li>`) > -1);
+  
+	let activeHtmlAnchor = EleventyNavigation.toHtml(obj, {
+		activeKey: "child1",
+		activeAnchorClass: "this-is-the-active-anchor"
+	});
+	t.true(activeHtmlAnchor.indexOf(`<li><a class="this-is-the-active-anchor" href="child1.html">child1</a></li>`) > -1);
+
+	let activeHtmlItemAndAnchor = EleventyNavigation.toHtml(obj, {
+		activeKey: "child1",
+		activeListItemClass: "this-is-the-active-item",
+		activeAnchorClass: "this-is-the-active-anchor"
+	});
+	t.true(activeHtmlItemAndAnchor.indexOf(`<li class="this-is-the-active-item"><a class="this-is-the-active-anchor" href="child1.html">child1</a></li>`) > -1);
 });
 
 test("Checking has children class on output HTML", t => {


### PR DESCRIPTION
Hello, this is my first pull request ever, hope I'm doing it right.

While working on a project using the BEM methodology, I noticed I needed support for custom classes for `<a>` tag (both in its base state and in active state).
I couldn't use a CSS selector like `.itemClass a { ... }` because the BEM methodology prohibits nesting of CSS classes, so I needed to programmatically output `<a class="some-classes">` myself. 

This is what I can now use in my project after the little changes I made:
```
{{ collections.all | eleventyNavigation | eleventyNavigationToHtml({
        listClass: "header__menu",
        listItemClass: "header__item",
        anchorClass: "link header__link",   <--- HERE
        activeAnchorClass: "header__link--active",   <--- HERE
        activeListItemClass: "header__link--active",
        activeKey: eleventyNavigation.key
}) | safe }}
```

Don't know if this could be helpful to someone, so I tried creating this pull request.