### PR TITLE
Option to include current page in breadcrumb

### DIFF
--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -46,16 +46,28 @@ function getDependencyGraph(nodes) {
 	return graph;
 }
 
-function findBreadcrumbEntries(nodes, activeKey) {
+function findBreadcrumbEntries(nodes, activeKey, includeActiveKey = false) {
 	let graph = getDependencyGraph(nodes);
+	let parentChildren = [];
 
-	return activeKey ? graph.dependenciesOf(activeKey).map(key => {
+	const parents = graph.dependenciesOf(activeKey).map(key => {
 		let data = Object.assign({}, graph.getNodeData(key));
+		parentChildren = data.children;
 		delete data.children;
 		data._isBreadcrumb = true;
 		return data;
-	}) : [];
+	});
+
+	if (includeActiveKey) {
+		let activeKeyData = parentChildren.filter(obj => obj.key == activeKey)[0];
+		delete activeKeyData.children;
+		activeKeyData._isBreadcrumb = true;
+		parents.push(activeKeyData);
+	}
+
+	return activeKey ? parents : [];
 }
+
 
 function navigationToHtml(pages, options = {}) {
 	options = Object.assign({


### PR DESCRIPTION
## Highlights
- Benefits (2, off the top of my head)
- Impact Level: (None). 


### Benefits
- For links not within a menu, I can easily get their link without worrying if it would change in the future.

  For example, a page with 
  ```
  permalink: false
  eleventyComputed:
    eleventyNavigation: 
      key: subscribe
      parent: home
      url: "{{ site.subscribeLink  | url}}"
  ```
may uses mailto:example@gmail.com, twitter.com/toheebdotcom as the url, or a custom page later in the future. Irrespective of this, standalone links should be able to get the link correctly if they reference by key.

An alternative to this approach will be to have a filter of the form eleventyNavigation('contact') that can access pages of ANY level. But that is not available and there is one more reason in favor of the former approach...

- Some breadcrumbs do include the current page as well.

### Impact Level
None!

Currently, breadcrumbs are done with 
```
collections.all | eleventyNavigationBreadcrumb('blog')
```

which is now implicitly:
```
collections.all | eleventyNavigationBreadcrumb('blog', false)
```

For current page to be included, it will now be:
```
collections.all | eleventyNavigationBreadcrumb('blog', true)
```

This way, updates won't affect previous implementation.
