### PR TITLE
findBreadcrumbEntries: Add handleMissing option

### DIFF
--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -48,6 +48,10 @@ function getDependencyGraph(nodes) {
 
 function findBreadcrumbEntries(nodes, activeKey, options = {}) {
 	let graph = getDependencyGraph(nodes);
+	if (options.handleMissing && !graph.hasNode(activeKey)) {
+		// Fail gracefully if the key isn't in the graph
+		return [];
+	}
 	let deps = graph.dependenciesOf(activeKey);
 	if(options.includeSelf) {
 		deps.push(activeKey);

--- a/test/navigationTest.js
+++ b/test/navigationTest.js
@@ -441,6 +441,15 @@ test("Breadcrumbs (include self)", t => {
 	t.is(obj[2].key, "grandchild1");
 });
 
+test("Breadcrumbs (options.handleMissing)", t => {
+	const entries = EleventyNavigation.findBreadcrumbEntries(
+		[],
+		"orphan",
+		{handleMissing: true}
+	);
+	t.is(entries.length, 0);
+});
+
 test("Output markdown", t => {
 	let obj = EleventyNavigation.findNavigationEntries([
 		{


### PR DESCRIPTION
Add the `handleMissing` option to `findBreadcrumbEntries`. When true, if `activeKey` is not found in `graph`, the function returns an empty array instead of throwing an exception.

A use case for this is a 404 error page with `eleventyExcludeFromCollections` enabled, but using a base template that includes `eleventyNavigationBreadcrumb`. By default, the error page would fail to render because it would look for the 404 page in the graph and not be able to find it.

Fixes #23 