### PR TITLE
Add aria-current option

### DIFF
--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -79,6 +79,15 @@ function getUrlFilter() {
 	}
 }
 
+function buildHtmlAttr(name, values) {
+	// values could be array or string
+	if (!values || !values.length) {
+		return '';
+	}
+	const valueStr = Array.isArray(values) ? values.join(" ") : [values];
+	return ` ${name}="${valueStr}"`;
+}
+
 function navigationToHtml(pages, options = {}) {
 	options = Object.assign({
 		listElement: "ul",
@@ -124,7 +133,8 @@ function navigationToHtml(pages, options = {}) {
 			liClass.push(options.listItemHasChildrenClass);
 		}
 
-		return `<${options.listItemElement}${liClass.length ? ` class="${liClass.join(" ")}"` : ''}><a href="${urlFilter(entry.url)}"${aClass.length ? ` class="${aClass.join(" ")}"` : ''}>${entry.title}</a>${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml.call(this, entry.children, options) : ""}</${options.listItemElement}>`;
+		const aTag = `<a href="${urlFilter(entry.url)}"${buildHtmlAttr('class', aClass)}>${entry.title}</a>`;
+		return `<${options.listItemElement}${buildHtmlAttr('class', liClass)}>${aTag}${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml.call(this, entry.children, options) : ""}</${options.listItemElement}>`;
 	}).join("\n")}</${options.listElement}>` : "";
 }
 

--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -103,6 +103,7 @@ function navigationToHtml(pages, options = {}) {
 		activeListItemClass: "",
 		anchorClass: "",
 		activeAnchorClass: "",
+		useAriaCurrentAttr: false,
 		showExcerpt: false,
 		isChildList: false
 	}, options);
@@ -132,6 +133,9 @@ function navigationToHtml(pages, options = {}) {
 			}
 			if(options.activeAnchorClass) {
 				aClass.push(options.activeAnchorClass);
+			}
+			if(options.useAriaCurrentAttr) {
+				aAttrs.push({ name: "aria-current", values: "page" });
 			}
 		}
 		if(options.listItemHasChildrenClass && entry.children && entry.children.length) {

--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -84,7 +84,7 @@ function buildHtmlAttr(name, values) {
 	if (!values || !values.length) {
 		return '';
 	}
-	const valueStr = Array.isArray(values) ? values.join(" ") : [values];
+	const valueStr = Array.isArray(values) ? values.join(" ") : values;
 	return ` ${name}="${valueStr}"`;
 }
 

--- a/eleventy-navigation.js
+++ b/eleventy-navigation.js
@@ -88,6 +88,10 @@ function buildHtmlAttr(name, values) {
 	return ` ${name}="${valueStr}"`;
 }
 
+function buildAllHtmlAttrs(attrs) {
+	return attrs.reduce((acc, { name, values }) => acc + buildHtmlAttr(name, values), '');
+}
+
 function navigationToHtml(pages, options = {}) {
 	options = Object.assign({
 		listElement: "ul",
@@ -115,6 +119,7 @@ function navigationToHtml(pages, options = {}) {
 	return pages.length ? `<${options.listElement}${!isChildList && options.listClass ? ` class="${options.listClass}"` : ''}>${pages.map(entry => {
 		let liClass = [];
 		let aClass = [];
+		let aAttrs = [];
 		if(options.listItemClass) {
 			liClass.push(options.listItemClass);
 		}
@@ -132,8 +137,11 @@ function navigationToHtml(pages, options = {}) {
 		if(options.listItemHasChildrenClass && entry.children && entry.children.length) {
 			liClass.push(options.listItemHasChildrenClass);
 		}
+		if(aClass.length) {
+			aAttrs.push({ name: "class", values: aClass });
+		}
 
-		const aTag = `<a href="${urlFilter(entry.url)}"${buildHtmlAttr('class', aClass)}>${entry.title}</a>`;
+		const aTag = `<a href="${urlFilter(entry.url)}"${buildAllHtmlAttrs(aAttrs)}>${entry.title}</a>`;
 		return `<${options.listItemElement}${buildHtmlAttr('class', liClass)}>${aTag}${options.showExcerpt && entry.excerpt ? `: ${entry.excerpt}` : ""}${entry.children ? navigationToHtml.call(this, entry.children, options) : ""}</${options.listItemElement}>`;
 	}).join("\n")}</${options.listElement}>` : "";
 }

--- a/test/navigationTest.js
+++ b/test/navigationTest.js
@@ -258,30 +258,32 @@ let fakeConfig = {
 	}
 };
 
-test("Checking active class on output HTML", t => {
-	let obj = EleventyNavigation.findNavigationEntries([
-		{
-			data: {
-				eleventyNavigation: {
-					key: "root1"
-				},
-				page: {
-					url: "root1.html"
-				}
-			}
-		},
-		{
-			data: {
-				eleventyNavigation: {
-					parent: "root1",
-					key: "child1"
-				},
-				page: {
-					url: "child1.html"
-				}
+let fakeNavigationEntries = [
+	{
+		data: {
+			eleventyNavigation: {
+				key: "root1"
+			},
+			page: {
+				url: "root1.html"
 			}
 		}
-	]);
+	},
+	{
+		data: {
+			eleventyNavigation: {
+				parent: "root1",
+				key: "child1"
+			},
+			page: {
+				url: "child1.html"
+			}
+		}
+	}
+];
+
+test("Checking active class on output HTML", t => {
+	let obj = EleventyNavigation.findNavigationEntries(fakeNavigationEntries);
 
 	let html = EleventyNavigation.toHtml.call(fakeConfig, obj);
 	t.true(html.indexOf(`<li><a href="child1.html">child1</a></li>`) > -1);
@@ -306,30 +308,21 @@ test("Checking active class on output HTML", t => {
 	t.true(activeHtmlItemAndAnchor.indexOf(`<li class="this-is-the-active-item"><a href="child1.html" class="this-is-the-active-anchor">child1</a></li>`) > -1);
 });
 
+test("Checking aria-current option on output HTML", t => {
+	let obj = EleventyNavigation.findNavigationEntries(fakeNavigationEntries);
+
+	let html = EleventyNavigation.toHtml.call(fakeConfig, obj);
+	t.true(html.indexOf(`<li><a href="child1.html">child1</a></li>`) > -1);
+
+	let activeHtmlAnchor = EleventyNavigation.toHtml.call(fakeConfig, obj, {
+		activeKey: "child1",
+		useAriaCurrentAttr: true
+	});
+	t.true(activeHtmlAnchor.indexOf(`<li><a href="child1.html" aria-current="page">child1</a></li>`) > -1);
+});
+
 test("Checking has children class on output HTML", t => {
-	let obj = EleventyNavigation.findNavigationEntries([
-		{
-			data: {
-				eleventyNavigation: {
-					key: "root1"
-				},
-				page: {
-					url: "root1.html"
-				}
-			}
-		},
-		{
-			data: {
-				eleventyNavigation: {
-					parent: "root1",
-					key: "child1"
-				},
-				page: {
-					url: "child1.html"
-				}
-			}
-		}
-	]);
+	let obj = EleventyNavigation.findNavigationEntries(fakeNavigationEntries);
 
 	let activeHtml = EleventyNavigation.toHtml.call(fakeConfig, obj, {
 		listItemHasChildrenClass: "item-has-children"


### PR DESCRIPTION
Fixes #14 

It adds a `useAriaCurrentAttr` option so that an anchor matching the `activeKey` will have an `aria-current="page"` attribute (see [more details here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current)).

**Example Nunjucks navigation rendering:**
```nunjucks
{{ collections.all | eleventyNavigation | eleventyNavigationToHtml({
    activeKey: eleventyNavigation.key,
    useAriaCurrentAttr: true
  }) | safe }}
```

 The PR also includes a refactor to make adding tag attributes a bit simpler.

- [x] Changes have test coverage
- [x] Have verified works in an Eleventy site build
- [ ] Documentation updated

